### PR TITLE
Enable relative line numbers

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -102,7 +102,7 @@ vim.g.have_nerd_font = true
 vim.o.number = true
 -- You can also add relative line numbers, to help with jumping.
 --  Experiment for yourself to see if you like it!
--- vim.o.relativenumber = true
+vim.o.relativenumber = true
 
 -- Enable mouse mode, can be useful for resizing splits for example!
 vim.o.mouse = 'a'


### PR DESCRIPTION
## Summary
- Uncomments `vim.o.relativenumber = true` in `init.lua` to persistently enable relative line numbers

## Test plan
- [ ] Open Neovim and verify relative line numbers appear in the gutter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
